### PR TITLE
Change the license owner to Swinject Contributors

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -897,6 +897,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = "Swinject Contributors";
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Example/SwinjectAutoregistration.xcodeproj/project.pbxproj
+++ b/Example/SwinjectAutoregistration.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0720;
-				ORGANIZATIONNAME = CocoaPods;
+				ORGANIZATIONNAME = "Swinject Contributors";
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;

--- a/Example/SwinjectAutoregistration/AppDelegate.swift
+++ b/Example/SwinjectAutoregistration/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  ACKSwinject
 //
 //  Created by Tomas Kohout on 08/30/2016.
-//  Copyright (c) 2016 Tomas Kohout. All rights reserved.
+//  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
 
 import UIKit

--- a/Example/SwinjectAutoregistration/ViewController.swift
+++ b/Example/SwinjectAutoregistration/ViewController.swift
@@ -3,7 +3,7 @@
 //  ACKSwinject
 //
 //  Created by Tomas Kohout on 08/30/2016.
-//  Copyright (c) 2016 Tomas Kohout. All rights reserved.
+//  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
 
 import UIKit

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Tomas Kohout <email@tomaskohout.cz>
+Copyright (c) 2016 Swinject Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SwinjectAutoregistration/Classes/Operators.swift
+++ b/SwinjectAutoregistration/Classes/Operators.swift
@@ -3,7 +3,7 @@
 //  Pods
 //
 //  Created by Tomas Kohout on 8/30/16.
-//
+//  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
 
 import Swinject


### PR DESCRIPTION
@tkohout, would you merge this pull request if you accept changing the license owner to Swinject Contributors?

[Swinject-CodeGen](https://github.com/Swinject/Swinject-CodeGen/blob/master/LICENSE) also has the same license owner. I would like to have the same license descriptions in all the projects under Swinject organization.

Your contribution is apparent in [Contributors page](https://github.com/Swinject/SwinjectAutoregistration/graphs/contributors), and it is ok to write your name in README as the main author of this project.