### PR TITLE
Fixed the dependency version specifier in Cartfile and Podspec

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.0.0"
+github "Swinject/Swinject" ~> 2.0

--- a/SwinjectAutoregistration.podspec
+++ b/SwinjectAutoregistration.podspec
@@ -18,5 +18,5 @@ SwinjectAutoregistration is an extension of Swinject that allows to automaticall
   s.requires_arc = true
 
   s.source_files = 'Sources/**/*.{swift,h}'
-  s.dependency 'Swinject', '>= 2.0.0'
+  s.dependency 'Swinject', '~> 2.0'
 end


### PR DESCRIPTION
Fixed the way to specify Swinject version to use v2.x.x (compatible versions with v2.0).
https://github.com/Swinject/SwinjectStoryboard/issues/48#issuecomment-296158221

Actually Cartfile doesn't need to be modified, but I changed it to align with podspec.

Pull request #22 reminded me of updating Cartfile and Podspec thankfully, and I thought it was good to use any Swinject v2.x.x and not v3.