### PR TITLE
Fix Android support

### DIFF
--- a/Sources/ResolutionError.swift
+++ b/Sources/ResolutionError.swift
@@ -21,10 +21,10 @@ enum ResolutionError {
 /// Shows warnings based on information parsed from initializers description
 
 func resolutionErrors<Service, Parameters>(forInitializer initializer: (Parameters) -> Service) -> [ResolutionError] {
-    #if os(Linux)
+    #if os(Linux) || os(Android)
         //Warnings are not supported on Linux
         return []
-    #endif
+    #else
     let parser = TypeParser(string: String(describing: Parameters.self))
     guard let type = parser.parseType() else { return [] }
     
@@ -47,6 +47,7 @@ func resolutionErrors<Service, Parameters>(forInitializer initializer: (Paramete
     }
     
     return warnings
+    #endif
 }
 
 func hasUnique(arguments: [Any.Type]) -> Bool {

--- a/Sources/TypeParser.swift
+++ b/Sources/TypeParser.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
     extension Scanner {
         func scanString(_ string: String) -> String? {
             var value: NSString?
@@ -187,7 +187,7 @@ class TypeParser {
         // See https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/swift/grammar/identifier-head
         
         //Identifier head
-        #if os(Linux)
+        #if os(Linux) || os(Android)
             var head = CharacterSet()
         #else
             let head = NSMutableCharacterSet()
@@ -215,7 +215,7 @@ class TypeParser {
         ranges.forEach { head.insert(charactersIn: $0) }
         
         //Identifier characters
-        #if os(Linux)
+        #if os(Linux) || os(Android)
             var characters = head
         #else
             let characters = head.copy() as! NSMutableCharacterSet

--- a/Tests/SwinjectAutoregistrationTests/TypeParserTests.swift
+++ b/Tests/SwinjectAutoregistrationTests/TypeParserTests.swift
@@ -5,7 +5,7 @@
 //  Created by Tomas Kohout on 20/01/2017.
 //  Copyright © 2017 Swinject Contributors. All rights reserved.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(Android)
 import XCTest
 import Quick
 import Nimble


### PR DESCRIPTION
Hi, I would like to use Swinject in my Android projects. 
Seems like small changes needed for that

I run tests on an Android device:
```
Test Suite 'All tests' started at 2020-08-08 11:23:05.233
Test Suite 'SwinjectAutoregistrationPackageTests-x86_64.xctest' started at 2020-08-08 11:23:05.236
Test Suite 'QuickSpec' started at 2020-08-08 11:23:05.236
Test Case 'QuickSpec.autoregistration, registers service with zero dependencies' started at 2020-08-08 11:23:05.236
Test Case 'QuickSpec.autoregistration, registers service with zero dependencies' passed (0.001 seconds)
Test Case 'QuickSpec.autoregistration, registers service with one dependency' started at 2020-08-08 11:23:05.237
Test Case 'QuickSpec.autoregistration, registers service with one dependency' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with two dependencies' started at 2020-08-08 11:23:05.237
Test Case 'QuickSpec.autoregistration, registers service with two dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with three dependencies' started at 2020-08-08 11:23:05.237
Test Case 'QuickSpec.autoregistration, registers service with three dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with four dependencies' started at 2020-08-08 11:23:05.238
Test Case 'QuickSpec.autoregistration, registers service with four dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with five dependencies' started at 2020-08-08 11:23:05.238
Test Case 'QuickSpec.autoregistration, registers service with five dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with six dependencies' started at 2020-08-08 11:23:05.238
Test Case 'QuickSpec.autoregistration, registers service with six dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with seven dependencies' started at 2020-08-08 11:23:05.239
Test Case 'QuickSpec.autoregistration, registers service with seven dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with eight dependencies' started at 2020-08-08 11:23:05.239
Test Case 'QuickSpec.autoregistration, registers service with eight dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with nine dependencies' started at 2020-08-08 11:23:05.239
Test Case 'QuickSpec.autoregistration, registers service with nine dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with twenty dependencies' started at 2020-08-08 11:23:05.239
Test Case 'QuickSpec.autoregistration, registers service with twenty dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with one dynamic argument' started at 2020-08-08 11:23:05.240
Test Case 'QuickSpec.autoregistration, registers service with one dynamic argument' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with two dynamic arguments' started at 2020-08-08 11:23:05.240
Test Case 'QuickSpec.autoregistration, registers service with two dynamic arguments' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with three dynamic arguments' started at 2020-08-08 11:23:05.240
Test Case 'QuickSpec.autoregistration, registers service with three dynamic arguments' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers with arguments interchangeably' started at 2020-08-08 11:23:05.241
Test Case 'QuickSpec.autoregistration, registers with arguments interchangeably' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, registers service with optional dependencies' started at 2020-08-08 11:23:05.241
Test Case 'QuickSpec.autoregistration, registers service with optional dependencies' passed (0.001 seconds)
Test Case 'QuickSpec.autoregistration, registers service with unwrapped dependencies' started at 2020-08-08 11:23:05.241
Test Case 'QuickSpec.autoregistration, registers service with unwrapped dependencies' passed (0.0 seconds)
Test Case 'QuickSpec.autoregistration, does not erase logging function' started at 2020-08-08 11:23:05.242
Test Case 'QuickSpec.autoregistration, does not erase logging function' passed (0.001 seconds)
Test Suite 'QuickSpec' passed at 2020-08-08 11:23:05.242
	 Executed 18 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
Test Suite 'SwinjectAutoregistrationPackageTests-x86_64.xctest' passed at 2020-08-08 11:23:05.242
	 Executed 18 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
Test Suite 'All tests' passed at 2020-08-08 11:23:05.242
	 Executed 18 tests, with 0 failures (0 unexpected) in 0.006 (0.006) seconds
```