### PR TITLE
Set VALID_ARCHS in xcconfig for consistency

### DIFF
--- a/Configurations/Mac OS X/Mac-Base.xcconfig
+++ b/Configurations/Mac OS X/Mac-Base.xcconfig
@@ -16,4 +16,4 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_pa
 SDKROOT = macosx
 
 // Supported build architectures
-VALID_ARCHS = x86_64
+VALID_ARCHS = $(ARCHS_STANDARD)

--- a/SwinjectAutoregistration.xcodeproj/project.pbxproj
+++ b/SwinjectAutoregistration.xcodeproj/project.pbxproj
@@ -1167,7 +1167,6 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-OSX";
-				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Debug;
 		};
@@ -1181,7 +1180,6 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-OSX";
-				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This is a small fix for PR #68. For consistency, we set the value in xcconfig. We took inspiration to set VALID_ARRCHS for ARM Mac. Thanks!