### PR TITLE
Update swinject, exclude arm64 on simulator

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.7.1"
+github "Swinject/Swinject" "2.8.0"

--- a/SwinjectAutoregistration.xcodeproj/project.pbxproj
+++ b/SwinjectAutoregistration.xcodeproj/project.pbxproj
@@ -833,6 +833,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD5B9E301D832A4F007ED05F /* iOS-Framework.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -847,6 +848,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD5B9E301D832A4F007ED05F /* iOS-Framework.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1000,6 +1002,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD5B9E3B1D832A4F007ED05F /* tvOS-Framework.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build",
@@ -1014,6 +1017,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD5B9E3B1D832A4F007ED05F /* tvOS-Framework.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build",


### PR DESCRIPTION
- I have tried the project with Xcode 13 RC and I've got `Missing path ios-arm64_i386_x86_64-simulator/dSYMs from XCFramework` error
- seems like main Swinject project excludes the arm64 architecture but SwinjectAutoregistration does not and it was causing this error
- I am aware that this should be fixed by https://github.com/Swinject/Swinject/pull/497 but for now, this makes the project compile under Xcode 13