### PR TITLE
Using Swinject 2.8.1

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["SwinjectAutoregistration"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.7.1")
+        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.1")
     ],
     targets: [
         .target(

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.8.1"
+github "Swinject/Swinject" ~> 2.8.1

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         
     ],
     dependencies: [
-        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.7.1")
+        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.1")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SwinjectAutoregistration is an extension of Swinject that allows to automaticall
 
 ## Requirements
 
-- iOS 8.0+ / Mac OS X 10.10+ / tvOS 9.0+
+- iOS 9.0+ / Mac OS X 10.10+ / tvOS 9.0+
 - Xcode 8+
 
 ## Installation
@@ -24,8 +24,8 @@ Swinject is available through [Carthage](https://github.com/Carthage/Carthage), 
 To install Swinject with Carthage, add the following line to your `Cartfile`.
 
 ```
-github "Swinject/Swinject" "2.7.0"
-github "Swinject/SwinjectAutoregistration" "2.7.0"
+github "Swinject/Swinject" "2.8.1"
+github "Swinject/SwinjectAutoregistration" "2.8.1"
 ```
 
 Then run `carthage update --use-xcframeworks --no-use-binaries` command or just `carthage update --use-xcframeworks`. For details of the installation and usage of Carthage, visit [its project page](https://github.com/Carthage/Carthage).
@@ -36,11 +36,11 @@ To install Swinject with CocoaPods, add the following lines to your `Podfile`.
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0' # or platform :osx, '10.10' if your target is OS X.
+platform :ios, '9.0' # or platform :osx, '10.10' if your target is OS X.
 use_frameworks!
 
-pod 'Swinject', '2.7.0'
-pod 'SwinjectAutoregistration', '2.7.0'
+pod 'Swinject', '2.8.1'
+pod 'SwinjectAutoregistration', '2.8.1'
 ```
 
 Then run `pod install` command. For details of the installation and usage of CocoaPods, visit [its official website](https://cocoapods.org).
@@ -51,7 +51,7 @@ in `Package.swift` add the following:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Swinject/SwinjectAutoregistration.git", from: "2.7.0")
+    .package(url: "https://github.com/Swinject/SwinjectAutoregistration.git", from: "2.8.1")
 ],
 targets: [
     .target(

--- a/SwinjectAutoregistration.podspec
+++ b/SwinjectAutoregistration.podspec
@@ -11,12 +11,12 @@ SwinjectAutoregistration is an extension of Swinject that allows to automaticall
   s.author           = 'Swinject Contributors'
   s.source           = { :git => 'https://github.com/Swinject/SwinjectAutoregistration.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   s.requires_arc = true
   s.swift_version = '5.0'
   s.source_files = 'Sources/**/*.{swift,h}'
-  s.dependency 'Swinject', '2.7.1'
+  s.dependency 'Swinject', '~> 2.8.1'
 end


### PR DESCRIPTION
This PR:
- Updates Carfile, Package.swift, and Podspec to use Swinject 2.8.1
- Updates the documentation
- Raises the minimum supported version of iOS platform to 9.0 (to match Swinject's)
- Uses Carthage and CocoaPods optimistic operator (~>) to specify the Swinject dependency, this way we can benefit from Swinject hotfixes without needing to change SwinjectAutoregistration podspec.