### PR TITLE
Allow resolution via a protocol for a service

### DIFF
--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -38,6 +38,21 @@ public func ~> <Service>(r: Resolver, service: Service.Type) -> Service {
     return r.resolve(service)!
 }
 
+/** Binary operator ~> equivalent to `r.resolve(Proto.Type)! as! Service`
+
+ Usage: `let mockImpl: MockImpl = r ~> DependencyA.self`
+ - Parameters:
+ - r: Resolver
+ - proto: Protocol implemented by the Service
+
+ - Returns: The resolved service type instance, retrieved via its registered protocol.
+ - Important: Fails on unresolvable service or casting error.
+ */
+infix operator ~~> : AdditionPrecedence
+public func ~~> <Proto, Service>(r: Resolver, proto: Proto.Type) -> Service {
+    return r.resolve(proto)! as! Service
+}
+
 /** Binary operator ~> equivalent to `r.resolve(Service.Type, name: "ServiceName")!`
  
  Usage: `SomeClass(dependencyA: r ~> (DependencyA.self, name: "ServiceName"))`

--- a/Tests/SwinjectAutoregistrationTests/OperatorsTests.swift
+++ b/Tests/SwinjectAutoregistrationTests/OperatorsTests.swift
@@ -5,29 +5,29 @@ import SwinjectAutoregistration
 
 
 class OperatorsTests: XCTestCase {
-	
+    class MockProtocolA: ProtocolA {}
     class DependencyA {}
     class DependencyB {}
     class DependencyC {}
     class DependencyD {}
-    
+
     class Service0 {}
-    
+
     class Service1 {
         init(a: String){}
     }
-    
+
     class Service2 {
         init(a: String, b: Int){}
     }
-    
+
     class Service3 {
         init(a: String, b: Int, c: Double){}
     }
 
-    
+
     var container: Container!
-    
+
     override func setUpWithError() throws {
         container = Container()
         container.register(Service0.self) { r in Service0() }
@@ -38,18 +38,19 @@ class OperatorsTests: XCTestCase {
         container.register(Service2.self, name: "MyService2") { r, a, b in Service2(a: a, b: b) }
         container.register(Service3.self) { r, a, b, c in Service3(a: a, b: b, c: c) }
         container.register(Service3.self, name: "MyService3") { r, a, b, c in Service3(a: a, b: b, c: c) }
+        container.register(ProtocolA.self) { r in MockProtocolA() }
     }
-    
+
     func testResolvingServiceUsingPostfixOperator() {
         let service: Service0 = container~>
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperator() {
         let service = container ~> Service0.self
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperatorWithName() {
         let service = container ~> (Service0.self, name: "MyService")
         XCTAssertNotNil(service)
@@ -69,49 +70,49 @@ class OperatorsTests: XCTestCase {
         // XCTAssertEqual(logs.count, 1)
     }
     #endif
-    
+
     func testResolvingServiceUsingInfixOperatorWith1DynamicArgument() {
         let service = container ~> (Service1.self, argument: "Arg1")
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperatorWithNameAnd1DynamicArgument() {
         let service = container ~> (Service1.self, name: "MyService1", argument: "Arg1")
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperatorWith2DynamicArguments() {
         let service = container ~> (Service2.self, arguments: ("Arg1", 5))
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperatorWithNameAnd2DynamicArguments() {
         let service: Service2 = container ~> (Service2.self, name: "MyService2", arguments: ("Arg1", 5))
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperatorWith3DynamicArguments() {
         let service = container ~> (Service3.self, arguments: ("Arg1", 5, 0.2))
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingInfixOperatorWithNameAnd3DynamicArguments() {
         let service = container ~> (Service3.self, name: "MyService3", arguments: ("Arg1", 5, 0.2))
         XCTAssertNotNil(service)
     }
-    
+
     func testResolvingServiceUsingDeprecatedInfixOperators() {
         //This call has been removed
         //let service2 = container ~> (Service2.self, arguments: "Arg1", 5)
-        
+
         //This never worked
         //let service2_name: Service2 = container ~> (Service2.self, name: "MyService2", arguments: "Arg1", 5)
-        
+
         //This is deprecated
         let service3 = container ~> (Service3.self, arguments: "Arg1", 5, 0.2)
         let service3_name = container ~> (Service3.self, name: "MyService3", arguments: "Arg1", 5, 0.2)
-        
-        
+
+
         XCTAssertNotNil(service3)
         XCTAssertNotNil(service3_name)
     }
@@ -121,9 +122,14 @@ class OperatorsTests: XCTestCase {
         XCTAssertNotNil(service)
     }
 
+    func testResolvingThruProtocol() {
+        let service: MockProtocolA? = container ~~> ProtocolA.self
+        XCTAssertNotNil(service)
+    }
+
     func testResolvingOptionalServiceUsingInfixOperator() {
         let service = container ~> Service0?.self
         XCTAssertNotNil(service)
     }
-	
+
 }


### PR DESCRIPTION
Our company makes heavy use of Swinject and SwinjectAutoregistration with Quick and Nimble.

# Problem: repeated boilerplate service resolution when using protocols

When we write tests, we found we used this pattern frequently:

```
var container: Container!
var mockApi: MockApi!

beforeEach {
  container = Container().customInjectionExtensionCode()
  mockApi = ((container ~> SomeApiProviding.self) as! MockApi)
}

justBeforeEach {
  // call some event that triggers the API
}

context("something") {
  beforeEach {
    mockApi.result = .success(SomeDomainModel.fixture)
  }
}
```

The code to resolve the MockApi via its protocol was repeated throughout our code. 

# Proposal: a new operator

Instead of calling:

```
mockApi = ((container ~> SomeApiProviding.self) as! MockApi)
```

Now, you can call:

```
mockApi = container ~~> SomeApiProviding.self
```

This PR uses type specifiers to determine the assigned type via the infix `~~>` operator and cast the return value accordingly.


