### PR TITLE
Increase deployment targets of all platforms to lowest possible version which is compatible with xCode 14.3

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["SwinjectAutoregistration"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.3")
+        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.4")
     ],
     targets: [
         .target(

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" ~> 2.8.3
+github "Swinject/Swinject" ~> 2.8.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.8.3"
+github "Swinject/Swinject" "2.8.4"

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,10 @@ let package = Package(
             name: "SwinjectAutoregistration-Dynamic",
             type: .dynamic,
             targets: ["SwinjectAutoregistration"])
-        
+
     ],
     dependencies: [
-        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.3")
+        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.4")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ SwinjectAutoregistration is an extension of Swinject that allows to automaticall
 
 ## Requirements
 
-- iOS 9.0+ / Mac OS X 10.10+ / tvOS 9.0+
-- Xcode 8+
+- iOS 11.0+ / Mac OS X 10.13+ / tvOS 11.0+
+- Xcode 14.3+
 
 ## Installation
 
@@ -36,7 +36,7 @@ To install Swinject with CocoaPods, add the following lines to your `Podfile`.
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0' # or platform :osx, '10.10' if your target is OS X.
+platform :ios, '11.0' # or platform :osx, '10.13' if your target is OS X.
 use_frameworks!
 
 pod 'Swinject', '2.8.3'

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Swinject is available through [Carthage](https://github.com/Carthage/Carthage), 
 To install Swinject with Carthage, add the following line to your `Cartfile`.
 
 ```
-github "Swinject/Swinject" "2.8.3"
-github "Swinject/SwinjectAutoregistration" "2.8.3"
+github "Swinject/Swinject" "2.8.4"
+github "Swinject/SwinjectAutoregistration" "2.8.4"
 ```
 
 Then run `carthage update --use-xcframeworks --no-use-binaries` command or just `carthage update --use-xcframeworks`. For details of the installation and usage of Carthage, visit [its project page](https://github.com/Carthage/Carthage).
@@ -39,8 +39,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '11.0' # or platform :osx, '10.13' if your target is OS X.
 use_frameworks!
 
-pod 'Swinject', '2.8.3'
-pod 'SwinjectAutoregistration', '2.8.3'
+pod 'Swinject', '2.8.4'
+pod 'SwinjectAutoregistration', '2.8.4'
 ```
 
 Then run `pod install` command. For details of the installation and usage of CocoaPods, visit [its official website](https://cocoapods.org).
@@ -51,7 +51,7 @@ in `Package.swift` add the following:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Swinject/SwinjectAutoregistration.git", from: "2.8.3")
+    .package(url: "https://github.com/Swinject/SwinjectAutoregistration.git", from: "2.8.4")
 ],
 targets: [
     .target(

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.3</string>
+	<string>2.8.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SwinjectAutoregistration.podspec
+++ b/SwinjectAutoregistration.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SwinjectAutoregistration'
-  s.version          = "2.8.3"
+  s.version          = "2.8.4"
   s.summary          = 'Autoregistration for Swinject'
   s.description      = <<-DESC
 SwinjectAutoregistration is an extension of Swinject that allows to automatically inject dependencies into registered services.
@@ -18,5 +18,5 @@ SwinjectAutoregistration is an extension of Swinject that allows to automaticall
   s.requires_arc = true
   s.swift_version = '5.0'
   s.source_files = 'Sources/**/*.{swift,h}'
-  s.dependency 'Swinject', '~> 2.8.3'
+  s.dependency 'Swinject', '~> 2.8.4'
 end

--- a/SwinjectAutoregistration.podspec
+++ b/SwinjectAutoregistration.podspec
@@ -11,10 +11,10 @@ SwinjectAutoregistration is an extension of Swinject that allows to automaticall
   s.author           = 'Swinject Contributors'
   s.source           = { :git => 'https://github.com/Swinject/SwinjectAutoregistration.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.watchos.deployment_target = '2.0'
-  s.tvos.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.watchos.deployment_target = '4.0'
+  s.tvos.deployment_target = '11.0'
   s.requires_arc = true
   s.swift_version = '5.0'
   s.source_files = 'Sources/**/*.{swift,h}'

--- a/SwinjectAutoregistration.xcodeproj/project.pbxproj
+++ b/SwinjectAutoregistration.xcodeproj/project.pbxproj
@@ -931,7 +931,7 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -997,7 +997,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VALIDATE_PRODUCT = YES;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -1044,7 +1044,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.swinject.SwinjectAutoregistration-iOS";
 			};
 			name = Debug;
@@ -1058,7 +1058,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.swinject.SwinjectAutoregistration-iOS";
 			};
 			name = Release;
@@ -1184,7 +1184,7 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-watchOS";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -1198,7 +1198,7 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-watchOS";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -1212,7 +1212,7 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-tvOS";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -1226,7 +1226,7 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-tvOS";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -1348,6 +1348,7 @@
 					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-OSX";
 			};
 			name = Debug;
@@ -1361,6 +1362,7 @@
 					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-OSX";
 			};
 			name = Release;
@@ -1414,7 +1416,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-OSXTests";
@@ -1468,7 +1470,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.swinject.SwinjectAutoregistration-OSXTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.3</string>
+	<string>2.8.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Increase deployment targets of all platforms to lowest possible version which is compatible with xCode 14.3
- Use new version of Swinject 2.8.4
- Update lib version to 2.8.4